### PR TITLE
Added task to update certificates

### DIFF
--- a/virtual-setup/roles/dci_setup/tasks/install.yml
+++ b/virtual-setup/roles/dci_setup/tasks/install.yml
@@ -5,6 +5,12 @@
     name: https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
     state: present
 
+- name: Update certificates
+  become: true
+  yum:
+    name: ca-certificates
+    state: latest
+
 - name: Install DCI-release
   become: true
   yum:


### PR DESCRIPTION
The certificates in the base image are outdated and the installation
of the DCI package can't continue.

This extra task will update the certificates before continue with
DCI install.